### PR TITLE
Fix: add observable items to the hash, not raw items

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function syncHash (array, hash, options) {
     // Add new items
     current.forEach(function (key, index) {
       if (hash.get(key)) return
-      hash.put(key, values ? items[index] : null)
+      hash.put(key, values ? array.get(index) : null)
     })
 
     // Delete old items

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "observ-array"
   ],
   "devDependencies": {
+    "observ": "~0.2.0",
     "observ-array": "~3.2.1",
     "observ-varhash": "~1.0.8",
     "standard": "^5.0.0",

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 var test = require('tape')
 var ObservArray = require('observ-array')
 var Hash = require('observ-varhash')
+var Observ = require('observ')
 var sync = require('./')
 
 test('simple', function (t) {
@@ -98,21 +99,25 @@ test('options.values', function (t) {
 
   var unlisten = sync(array, hash, {key: 'id', values: true})
 
-  array.push({id: 1, foo: 'a'}, {id: 2, foo: 'b'})
+  var item1 = Observ({id: 1, foo: 'a'})
+  var item2 = Observ({id: 2, foo: 'b'})
+  array.push(item1, item2)
 
   t.deepEqual(hash(), {
     1: {id: 1, foo: 'a'},
     2: {id: 2, foo: 'b'}
   }, 'adds hash items with values')
 
-  // Saves references to values
-  t.equal(hash()['1'], array()[0], 'saves reference')
+  t.equal(hash[1], item1, 'saves observ reference')
+  t.equal(hash[2], item2, 'saves observ reference')
 
   array.splice(0, 1)
 
   t.deepEqual(hash(), {
     2: {id: 2, foo: 'b'}
   }, 'removes hash items with values')
+
+  t.equal(hash[2], item2, 'saves observ reference')
 
   unlisten()
 


### PR DESCRIPTION
Had this fix locally yesterday, forgot to PR it.

This makes it so the hash gets the observable  version of the values in the array, not the raw version.
